### PR TITLE
Fix: ci run htmlproofer lst

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS file sets rules for who should be notified when a pull request
+# modifies code in a specific path.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners for more information.
+
+# Configuration parameters for site
+conf.py                  @lwasser @kierisi
+CNAME                        @lwasser @kierisi
+
+# Workflow files for GitHub Actions
+.github/**                   @lwasser @willingc
+
+# Scripts
+scripts/*                    @lwasser @willingc

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Test for bad links and ensure alt tags for usability
       - name: Check HTML using htmlproofer
-        uses: chabad360/htmlproofer@V2
+        uses: chabad360/htmlproofer@v2
         with:
           directory: '_build/html'
           arguments: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch main
-        run: |
-          git fetch origin main --depth 1
-          git branch
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -37,6 +32,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
       - name: Install dependencies
         run: python3 -m pip install nox
 
@@ -49,24 +45,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/html
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      # Test for bad links and ensure alt tags for usability
+      - name: Check HTML using htmlproofer
+        uses: chabad360/htmlproofer@V2
         with:
-          ruby-version: 3
-
-      - name: Install gems
-        run: |
-          gem install html-proofer
-          gem install typhoeus
-
-      - name: Cache HTMLProofer
-        id: cache-htmlproofer
-        uses: actions/cache@v4
-        with:
-          path: tmp/.htmlproofer
-          key: ${{ runner.os }}-htmlproofer
-
-      - name: Run htmlproofer
-        run: |
-          ruby scripts/htmlproofer.rb
-          ls
+          directory: '_build/html'
+          arguments: |
+            --ignore-files "/.+\/_static\/.+/,/genindex.html/"
+            --ignore-status-codes "302, 404, 403, 429, 503"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,12 +10,12 @@ jobs:
   build-book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Upgrade pip
         run: |
@@ -26,7 +26,7 @@ jobs:
         run: echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -37,16 +37,16 @@ jobs:
 
       - run: nox -s docs
 
-      - name: Check HTML using htmlproofer
-        uses: chabad360/htmlproofer@master
-        with:
-          directory: '_build/html'
-          arguments: |
-           --ignore-files "/.+\/_static\/.+/,/.+\/reference\/meeting-notes\/.+/"
-
       - name: Push to gh-pages branch for publication from main
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/html
+
+      - name: Check HTML using htmlproofer
+        uses: chabad360/htmlproofer@master
+        with:
+          directory: '_build/html'
+          arguments: |
+           --ignore-files "/.+\/_static\/.+/,/.+\/reference\/meeting-notes\/.+/"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Fetch main
+        run: |
+          git fetch origin main --depth 1
+          git branch
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -49,19 +49,19 @@ jobs:
         with:
           ruby-version: 3
 
-        - name: Install gems
-          run: |
-            gem install html-proofer
-            gem install typhoeus
+      - name: Install gems
+        run: |
+          gem install html-proofer
+          gem install typhoeus
 
-        - name: Cache HTMLProofer
-          id: cache-htmlproofer
-          uses: actions/cache@v4
-          with:
-            path: tmp/.htmlproofer
-            key: ${{ runner.os }}-htmlproofer
+      - name: Cache HTMLProofer
+        id: cache-htmlproofer
+        uses: actions/cache@v4
+        with:
+          path: tmp/.htmlproofer
+          key: ${{ runner.os }}-htmlproofer
 
-        - name: Run htmlproofer
-          run: |
-            ruby scripts/htmlproofer.rb
-            ls
+      - name: Run htmlproofer
+        run: |
+          ruby scripts/htmlproofer.rb
+          ls

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -44,10 +44,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/html
 
-      - name: Check HTML using htmlproofer
-        uses: chabad360/htmlproofer@master
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          directory: '_build/html'
-          arguments: |
-           --ignore-files "/.+\/_static\/.+/,/.+\/reference\/meeting-notes\/.+/"
-           --ignore-status-codes "200, 403, 429, 503"
+          ruby-version: 3
+
+        - name: Install gems
+          run: |
+            gem install html-proofer
+            gem install typhoeus
+
+        - name: Cache HTMLProofer
+          id: cache-htmlproofer
+          uses: actions/cache@v4
+          with:
+            path: tmp/.htmlproofer
+            key: ${{ runner.os }}-htmlproofer
+
+        - name: Run htmlproofer
+          run: |
+            ruby scripts/htmlproofer.rb
+            ls

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,3 +50,4 @@ jobs:
           directory: '_build/html'
           arguments: |
            --ignore-files "/.+\/_static\/.+/,/.+\/reference\/meeting-notes\/.+/"
+           --ignore-status-codes "200, 403, 429, 503"

--- a/reference/meeting-notes/2019/2019-04-04-notes.md
+++ b/reference/meeting-notes/2019/2019-04-04-notes.md
@@ -58,12 +58,12 @@ https://hackmd.io/ixwWjxq7S2msYEZcZ3gV-Q
         * or a link to the issue
         * does rOpenSci do surveys??? followup on that -- followup with Steph B about this ??
 
-
+<div data-proofer-ignore>
 4. Go over the review steps
     * Review [overview/timeline](https://www.pyopensci.org/dev_guide/peer_review/peer_review_proc.html#review-timeline)
     * What is the editor's role? Editor [template](https://www.pyopensci.org/dev_guide/appendices/templates.html#editors-template) and [checklist](https://www.pyopensci.org/dev_guide/peer_review/editor_guide.html#editor-checklist)
     * How to review? Reviewer [template](https://www.pyopensci.org/dev_guide/appendices/templates.html#review-template) and [guide](https://www.pyopensci.org/dev_guide/peer_review/reviewer_guide.html)
-
+</div>
 
 JOSS potential issues
 * what packages they don't accept -- ie they don't accept API wrappers

--- a/reference/meeting-notes/2019/2019-05-09-notes.md
+++ b/reference/meeting-notes/2019/2019-05-09-notes.md
@@ -43,7 +43,7 @@ https://hackmd.io/ewQZvQdFSteXh3OXJIJPdw
         *  Ropensci is talking with Arfon as well. JOSS requires a zenodo doi, they want to ensure the version of the package is accepted is linked to a DOI. DOI's are relevant for JOSS but not explicitly tracked in the ropensci process. The DOI for the final version in the review is used for JOSS.
         *  ropensci has a diagnostic package that they use to provide some feedback and it's run on submission in a standardized envt... and the bot will be able to spit out results
         *  They've had a few scenarios where authors have requested an updated review. It's not practical... because it's resource intensive...
-    *  [Current whedon functionality](+)
+    *  Current whedon functionality
     *  * one we get feedback on the bot, send all of the input to karthik, arfon and noam
     *  Linsdey -- dashboard with whedon -- allows them to look at editor and reviewer loads, etc etc... that is super helpful. JOSS backend might be a google sheet.
 

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -1,0 +1,49 @@
+require "html-proofer"
+require "typhoeus"
+
+begin
+  directories = ['../_site']
+  status_codes = [0, 200, 301, 403, 429, 503, 999]
+  merge_base = %x(git merge-base origin/main HEAD).chomp
+  diffable_files = %x(git diff -z --name-only --diff-filter=AC #{merge_base}).split("\0")
+  diffable_files = diffable_files.select do |filename|
+    next true if directories.include?(File.dirname(filename))
+
+    filename.end_with?(".md")
+  end.map { |f| Regexp.new(File.basename(f, File.extname(f))) }
+
+  # Add urls for it to ignore
+  diffable_files << %r{^https://fonts\.gstatic\.com.*}
+  diffable_files << %r{^https://fonts\.googleapis\.com.*}
+
+  # Create a file to capture errors
+  errors = StringIO.new
+  HTMLProofer.check_directory(
+    "./_site",
+    {
+      ignore_urls: diffable_files,
+      ignore_status_codes: status_codes,
+      cache: {
+        timeframe: {
+          external: "7d",
+          internal: "7d"
+        }
+      },
+      typhoeus: {
+        verbose: false,
+        ssl_verifyhost: 1
+      }
+    }
+  ).run { |message| errors.puts message }
+
+   # Write errors to a text file
+   File.write("html_proofer_errors.txt", errors.string)
+
+rescue StandardError => e
+  # Print out the error message
+  puts "An error occurred: #{e.message}"
+  # Print out backtrace if needed
+  puts e.backtrace.join("\n")
+  # Exit with a non-zero status code to indicate failure
+  exit 1
+end

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -2,8 +2,10 @@ require "html-proofer"
 require "typhoeus"
 
 begin
-  directories = ['../_site']
-  status_codes = [0, 200, 301, 403, 429, 503, 999]
+  extensions = ['.html']
+  directories = ['../_build/html']
+  ignore_files = ['./_build/html/_static/webpack-macros.html']
+  status_codes = [0, 200, 301, 403, 410, 429, 503, 999]
   merge_base = %x(git merge-base origin/main HEAD).chomp
   diffable_files = %x(git diff -z --name-only --diff-filter=AC #{merge_base}).split("\0")
   diffable_files = diffable_files.select do |filename|
@@ -19,9 +21,11 @@ begin
   # Create a file to capture errors
   errors = StringIO.new
   HTMLProofer.check_directory(
-    "./_site",
+    "./_build/html",
     {
+      extensions: extensions,
       ignore_urls: diffable_files,
+      ignore_files: ignore_files,
       ignore_status_codes: status_codes,
       cache: {
         timeframe: {

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -5,7 +5,7 @@ begin
   extensions = ['.html']
   directories = ['../_build/html']
   ignore_files = ['./_build/html/_static/webpack-macros.html']
-  status_codes = [0, 200, 301, 403, 410, 429, 503, 999]
+  status_codes = [0, 200, 301, 302, 403, 410, 429, 503, 999]
   merge_base = %x(git merge-base origin/main HEAD).chomp
   diffable_files = %x(git diff -z --name-only --diff-filter=AC #{merge_base}).split("\0")
   diffable_files = diffable_files.select do |filename|


### PR DESCRIPTION
This runs htmlproofer last. that way it can publish to gh pages if merged into main but we assume that if there are things we want to fix, we can do that in the pr. 

this will avoid the issue of a new page "breaking" the build but we still want to publish because it is a new page that we want online and it is causing the error