### PR TITLE
Fix: ignore meeting notes dir

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           directory: '_build/html'
           arguments: |
-            --ignore-files "/.+\/_static\/.+/,/genindex.html/"
+            --ignore-files "/.+\/_static\/.+/,/genindex.html/,/.+\/reference\/.+/"
             --ignore-status-codes "302, 404, 403, 429, 503"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -52,4 +52,4 @@ jobs:
           directory: '_build/html'
           arguments: |
             --ignore-files "/.+\/_static\/.+/,/genindex.html/,/.+\/reference\/.+/"
-            --ignore-status-codes "302, 404, 403, 429, 503"
+            --ignore-status-codes "200, 302, 404, 403, 429, 503"

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 This guide is designed to define the structure and processes
 that support operations of pyOpenSci.
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/pyopensci/governance?color=purple&display_name=tag&style=plastic)  [![DOI](https://zenodo.org/badge/161679308.svg)](https://zenodo.org/badge/latestdoi/161679308) [![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)](#contributors-)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/pyopensci/governance?color=purple&display_name=tag&style=plastic)  [![DOI](https://zenodo.org/badge/161679308.svg)](https://zenodo.org/badge/latestdoi/161679308) [![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)]()
 
 :::::{grid} 1 1 3 3
 :class-container: text-center

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ that support operations of pyOpenSci.
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pyopensci/governance?color=purple&display_name=tag&style=plastic)  [![DOI](https://zenodo.org/badge/161679308.svg)](https://zenodo.org/badge/latestdoi/161679308) [![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)]()
 
+
 :::::{grid} 1 1 3 3
 :class-container: text-center
 :gutter: 3


### PR DESCRIPTION
no reason to link check old meeting notes. this pr should tell htmlproofer to ignore. 